### PR TITLE
Implement native logging features

### DIFF
--- a/BotCommands/play.py
+++ b/BotCommands/play.py
@@ -3,6 +3,10 @@ import discord
 import asyncio
 import json
 from discord.ext import commands
+import logging
+
+logger = logging.getLogger(__name__)
+
 #simport bot
 
 #client = commands.Bot(command_prefix='!') #Command prefix
@@ -27,10 +31,12 @@ class Basic(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-    
+
     # !play command
     @commands.command()
-    async def play(self, ctx, arg): 
+    async def play(self, ctx, arg):
+        logger.debug("Play command called")
+
         if arg == "reset":
             await ctx.send('Ok! Setting my playing status to: `default`')
             await commands.change_presence(activity=discord.Game(name=f'Hello! I am the NDD Bot! version {bot_branch}|{bot_version}'))

--- a/bot.py
+++ b/bot.py
@@ -1,14 +1,14 @@
 # bot.py
 import os
-import time
 import discord
 import random
 import json
 import threading
 import asyncio
-import logging
+import logging.config
 from dotenv import load_dotenv
 from discord.ext import commands
+from pathlib import Path
 
 import BotCommands.ping
 import BotCommands.ver
@@ -19,22 +19,13 @@ import BotCommands.reload
 import BotCommands.__init__
 # In the future this huge list of "import BotCommands" wil be deleted
 
+# Initial Setup
+logging.config.fileConfig("{}/logging.ini".format(Path(__file__).parent.absolute()))
+logger = logging.getLogger(__name__)
 
 # LOAD CONFIG FILE
 with open('config.json') as config:
     json_data = json.load(config)
-
-
-
-
-localtime = time.asctime(time.localtime(time.time()))
-
-
-logger = logging.getLogger('discord')
-logger.setLevel(logging.DEBUG)
-handler = logging.FileHandler(filename='discord.log', encoding='utf-8', mode='w')
-handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
-logger.addHandler(handler)
 
 '''
 ------------------------------------------------
@@ -72,16 +63,16 @@ client = commands.Bot(command_prefix=bot_prefix) #Command prefix
 
 @client.event
 async def on_ready():  # When the bot is connected to Discord do:
-    log('Setting discord presence...')
+    logger.debug('Setting discord presence...')
     await client.change_presence(activity=discord.Game(name=f'Hello! I am the NDD Bot! version {bot_branch}|{bot_version}')) # Set presence
-    log('Loading Cogs...')
+    logger.debug('Loading Cogs...')
     loadCogsCommands(BotCommands) # Load cogs from ./BotCommands
-    log('------')
-    log('| Logged in as')
-    log(f'| {client.user.name}')
-    log(f'| ID: {client.user.id}')
-    log('------')
-    log('Bot is ready')
+    logger.debug('------')
+    logger.debug('| Logged in as')
+    logger.debug(f'| {client.user.name}')
+    logger.debug(f'| ID: {client.user.id}')
+    logger.debug('------')
+    logger.debug('Bot is ready')
     
 
 
@@ -132,16 +123,16 @@ async def debug_error(ctx, error):
 @client.event
 async def on_member_join(member): # when a user joins a guild do:
 
-    log('on_member_join event triggered')
+    logger.debug('on_member_join event triggered')
 
     for channel in member.guild.channels: #search the channel
-        log(f'- - - Searching the "{welcome_ch_name}" channel...- - - ')
-        log(f'ID is <{welcome_ch_id}>')
-        log(f'Is "{str(channel)}" id the same as "{welcome_ch_name} id" ? {str(channel.id) == welcome_ch_id}')
+        logger.debug(f'- - - Searching the "{welcome_ch_name}" channel...- - - ')
+        logger.debug(f'ID is <{welcome_ch_id}>')
+        logger.debug(f'Is "{str(channel)}" id the same as "{welcome_ch_name} id" ? {str(channel.id) == welcome_ch_id}')
 
         if str(channel.id) == welcome_ch_id: #compare channels id
-            log(f'{welcome_ch_name} channel found.')
-            log(f'- - - Done. Sending to the channel "{welcome_ch_name}" the welcome messagge- - - ')
+            logger.debug(f'{welcome_ch_name} channel found.')
+            logger.debug(f'- - - Done. Sending to the channel "{welcome_ch_name}" the welcome messagge- - - ')
 
             await channel.send(f'{member.mention}{join_msg}') # Send the "chwelcome_msg" object value to the channel
             await member.send(f'Benvenut* {member.mention}{welcome_dm}') # Send the "chwelcome_dm" object value to the user
@@ -151,16 +142,16 @@ async def on_member_join(member): # when a user joins a guild do:
 @client.event
 async def on_member_remove(member): # when a user joins a guild do:
 
-    log('on_member_remove event triggered')
+    logger.debug('on_member_remove event triggered')
 
     for channel in member.guild.channels: #search the channel
-        log(f'- - - Searching the "{welcome_ch_name}" channel...- - - ')
-        log(f'ID is <{welcome_ch_id}>')
-        log(f'Is "{str(channel)}" id the same as "{welcome_ch_name} id" ? {str(channel.id) == welcome_ch_id}')
+        logger.debug(f'- - - Searching the "{welcome_ch_name}" channel...- - - ')
+        logger.debug(f'ID is <{welcome_ch_id}>')
+        logger.debug(f'Is "{str(channel)}" id the same as "{welcome_ch_name} id" ? {str(channel.id) == welcome_ch_id}')
 
         if str(channel.id) == welcome_ch_id: #compare channels id
-            log(f'{welcome_ch_name} channel found.')
-            log(f'- - - Done. Sending to the channel "{welcome_ch_name}" the welcome messagge- - - ')
+            logger.debug(f'{welcome_ch_name} channel found.')
+            logger.debug(f'- - - Done. Sending to the channel "{welcome_ch_name}" the welcome messagge- - - ')
 
             await channel.send(f'{member.mention}{left_msg}') 
             #await member.send(f'Benvenut* {member.mention}{welcome_dm}') # There is no DM left message
@@ -175,20 +166,5 @@ def loadCogsCommands(_dir):
     client.add_cog(_dir.play.Basic(client))
     client.add_cog(_dir.changelog.Basic(client))
     client.add_cog(_dir.reload.Basic(client))
-
-
-def log(txt):    
-    
-    print(f'[{localtime}]: {txt}\n')
-    with open("./bot.log", "a") as debugFile:
-        debugFile.write(f'[{localtime}]: {txt}\n')
-        print(debugFile.closed)
-
-    print(debugFile.closed)
-
-
-
-
-
 
 client.run(TOKEN) #Start the bot

--- a/logging.ini
+++ b/logging.ini
@@ -1,0 +1,27 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=fileHandler
+
+[formatters]
+keys=basicFormatter
+
+[logger_root]
+level=DEBUG
+handlers=fileHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=basicFormatter
+args=(sys.stdout,)
+
+[handler_fileHandler]
+class=FileHandler
+level=DEBUG
+formatter=basicFormatter
+args=("discord.log",)
+
+[formatter_basicFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s: %(message)s

--- a/logging.ini
+++ b/logging.ini
@@ -1,8 +1,8 @@
 [loggers]
-keys=root
+keys=root,playCommand
 
 [handlers]
-keys=fileHandler
+keys=fileHandler,consoleHandler
 
 [formatters]
 keys=basicFormatter
@@ -10,6 +10,12 @@ keys=basicFormatter
 [logger_root]
 level=DEBUG
 handlers=fileHandler
+
+[logger_playCommand]
+level=DEBUG
+handlers=consoleHandler
+qualname=BotCommands.play
+propagate=0
 
 [handler_consoleHandler]
 class=StreamHandler


### PR DESCRIPTION
I've removed the custom-made logging function and replaced it with Python's logging features. I've made it so that it behaves the same as the old function, and there is a `consoleHandler` ready in case we want to use it.

This can be expanded to include logging specific to each command.

In each command's file, you can get its own logger like so:
```logger = logging.getLogger(__name__)```

`__name__` will be `"BotCommands.play"` for `BotCommands/play.py`.

Then, if specific needs require it, you can also create a new entry in the logging.ini for a command. In the example I've added in this PR, I've made it so that the Play command will log in the console. The log won't propagate to the root logger, so you won't see any logging from the Play command in `discord.log`.

**logging.ini: logger for the play command**
```
[logger_playCommand]
level=DEBUG
handlers=consoleHandler
qualname=BotCommands.play
propagate=0
```

`qualname` is required to map a Python module to a simple name for the logger (in this case it's `playCommand`). The extra logger needs then to be in the `[loggers]` list.